### PR TITLE
HUD offset update

### DIFF
--- a/hud.lua
+++ b/hud.lua
@@ -64,7 +64,7 @@ local function get_hud_slot(effect)
 	data.huds[slot] = { effect = effect,
 	offset = {
 		x = hud_template.alignment.x * hud_template.offset.x,
-		y = (slot-1) * hud_template.offset.y } }
+		y = hud_template.alignment.y * (slot-1) * hud_template.offset.y } }
 	return slot
 end
 

--- a/hud.lua
+++ b/hud.lua
@@ -19,8 +19,9 @@
 local hud_update_period = 0.3
 local hud_template = {
 	position = { x=1, y=0.2 },
-	alignment = { x=-1, y=-1 },
-	offset = { x = 18, y = 34},
+	alignment = { x=-1, y=1 },
+	offset = { x = 18, y = 18},
+	spacing = 34,
 	icon_scale = 1.7,
 	max_anim = 25
 }
@@ -37,14 +38,17 @@ hud_template.alignment.x = tonumber(minetest.settings:get(
 hud_template.alignment.y = tonumber(minetest.settings:get(
 "late.hud.alignment.y")) or hud_template.alignment.y
 
-hud_template.icon_scale = tonumber(minetest.settings:get(
-"late.hud.icon_scale")) or hud_template.icon_scale
-
 hud_template.offset.x = tonumber(minetest.settings:get(
 "late.hud.offset.x")) or hud_template.offset.x
 
 hud_template.offset.y = tonumber(minetest.settings:get(
 "late.hud.offset.y")) or hud_template.offset.y
+
+hud_template.spacing = tonumber(minetest.settings:get(
+"late.hud.spacing")) or hud_template.spacing
+
+hud_template.icon_scale = tonumber(minetest.settings:get(
+"late.hud.icon_scale")) or hud_template.icon_scale
 
 local function get_hud_slot(effect)
 	local data = late.get_storage_for_target(effect.target)
@@ -61,10 +65,14 @@ local function get_hud_slot(effect)
 	local slot = 1
 	while data.huds[slot] do slot = slot + 1 end
 
-	data.huds[slot] = { effect = effect,
-	offset = {
-		x = hud_template.alignment.x * hud_template.offset.x,
-		y = hud_template.alignment.y * (slot-1) * hud_template.offset.y } }
+	data.huds[slot] = {
+		effect = effect,
+		offset = {
+			x = hud_template.alignment.x * hud_template.offset.x,
+			y = hud_template.alignment.y * ( hud_template.offset.y + (slot-1)
+				* hud_template.spacing )
+		}
+	}
 	return slot
 end
 

--- a/hud.lua
+++ b/hud.lua
@@ -70,7 +70,7 @@ local function get_hud_slot(effect)
 		offset = {
 			x = hud_template.alignment.x * hud_template.offset.x,
 			y = hud_template.alignment.y * ( hud_template.offset.y + (slot-1)
-				* hud_template.spacing )
+				* (hud_template.spacing + hud_template.icon_scale * 16))
 		}
 	}
 	return slot

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,7 +1,8 @@
 late.hud.position.x (Horizontal position of HUD) float 1
 late.hud.position.y (Vertical position of HUD) float 0.2
 late.hud.alignment.x (Horizontal alignment of HUD) float -1
-late.hud.alignment.y (Vertical alignment of HUD) float -1
+late.hud.alignment.y (Vertical alignment of HUD) float 1
+late.hud.offset.x (Horizontal offset of HUD) int 18
+late.hud.offset.y (Vertical offset of HUD) int 18
+late.hud.spacing (Size of space between effects) 34
 late.hud.icon_scale (Scale factor of 16px effect icon) float 1.7
-late.hud.offset.x (Horizontal offset of effect) int 18
-late.hud.offset.y (Vertical offset of effect) int 34


### PR DESCRIPTION
Sorry that you'll have to force merge this. I didn't see your merge before I sneakily updated the previous commit, shouldn't have done that regardless.

Any way, this makes both x and y offset behave the same, as a general positioning setting for the whole of the effect HUD. `hud_template.spacing` is replacing the old use of `hud_template.offset.y`. 